### PR TITLE
Specify value to use for points outside the volume.

### DIFF
--- a/neuron/layers.py
+++ b/neuron/layers.py
@@ -212,6 +212,7 @@ class SpatialTransformer(Layer):
                  interp_method='linear',
                  indexing='ij',
                  single_transform=False,
+                 fill_value=None,
                  **kwargs):
         """
         Parameters: 
@@ -220,8 +221,11 @@ class SpatialTransformer(Layer):
             indexing (default: 'ij'): 'ij' (matrix) or 'xy' (cartesian)
                 'xy' indexing will have the first two entries of the flow 
                 (along last axis) flipped compared to 'ij' indexing
+            fill_value (default: None): value to use for points outside the domain.
+                If None, the nearest neighbors will be used.
         """
         self.interp_method = interp_method
+        self.fill_value = fill_value
         self.ndims = None
         self.inshape = None
         self.single_transform = single_transform
@@ -316,7 +320,7 @@ class SpatialTransformer(Layer):
         return affine_to_shift(trf, volshape, shift_center=True)
 
     def _single_transform(self, inputs):
-        return transform(inputs[0], inputs[1], interp_method=self.interp_method)
+        return transform(inputs[0], inputs[1], interp_method=self.interp_method, fill_value=self.fill_value)
 
 
 class VecInt(Layer):

--- a/neuron/utils.py
+++ b/neuron/utils.py
@@ -37,7 +37,7 @@ from tensorflow import keras
 import tensorflow.keras.backend as K
 reload(pl)
 
-def interpn(vol, loc, interp_method='linear'):
+def interpn(vol, loc, interp_method='linear', fill_value=None):
     """
     N-D gridded interpolation in tensorflow
 
@@ -50,6 +50,8 @@ def interpn(vol, loc, interp_method='linear'):
             each tensor has to have the same size (but not nec. same size as vol)
             or a tensor of size [*new_vol_shape, D]
         interp_method: interpolation type 'linear' (default) or 'nearest'
+        fill_value: value to use for points outside the domain. If None, the nearest
+            neighbors will be used (default).
 
     Returns:
         new interpolated volume of the same size as the entries in loc
@@ -82,12 +84,17 @@ def interpn(vol, loc, interp_method='linear'):
     else:
         volshape = vol.shape
 
+    max_loc = [d - 1 for d in vol.get_shape().as_list()]
+    if fill_value is not None:
+        below = [tf.less(loc[...,d], 0) for d in range(nb_dims)]
+        above = [tf.greater(loc[...,d], max_loc[d]) for d in range(nb_dims)]
+        out_of_bounds = tf.reduce_any(tf.stack(below + above, axis=-1), axis=-1, keepdims=True)
+
     # interpolate
     if interp_method == 'linear':
         loc0 = tf.floor(loc)
 
         # clip values
-        max_loc = [d - 1 for d in vol.get_shape().as_list()]
         clipped_loc = [tf.clip_by_value(loc[...,d], 0, max_loc[d]) for d in range(nb_dims)]
         loc0lst = [tf.clip_by_value(loc0[...,d], 0, max_loc[d]) for d in range(nb_dims)]
 
@@ -139,9 +146,6 @@ def interpn(vol, loc, interp_method='linear'):
     else:
         assert interp_method == 'nearest'
         roundloc = tf.cast(tf.round(loc), 'int32')
-
-        # clip values
-        max_loc = [tf.cast(d - 1, 'int32') for d in vol.shape]
         roundloc = [tf.clip_by_value(roundloc[...,d], 0, max_loc[d]) for d in range(nb_dims)]
 
         # get values
@@ -150,6 +154,11 @@ def interpn(vol, loc, interp_method='linear'):
         # interp_vol = tf.gather_nd(vol, roundloc)
         idx = sub2ind(vol.shape[:-1], roundloc)
         interp_vol = tf.gather(tf.reshape(vol, [-1, vol.shape[-1]]), idx) 
+
+    if fill_value is not None:
+        fill_value = tf.constant(fill_value, dtype='float32')
+        interp_vol *= tf.cast(tf.logical_not(out_of_bounds), dtype='float32')
+        interp_vol += tf.cast(out_of_bounds, dtype='float32') * fill_value
 
     return interp_vol
 
@@ -253,7 +262,7 @@ def affine_to_shift(affine_matrix, volshape, shift_center=True, indexing='ij'):
     return loc - tf.stack(mesh, axis=nb_dims)
 
 
-def transform(vol, loc_shift, interp_method='linear', indexing='ij'):
+def transform(vol, loc_shift, interp_method='linear', indexing='ij', fill_value=None):
     """
     transform (interpolation N-D volumes (features) given shifts at each location in tensorflow
 
@@ -267,6 +276,8 @@ def transform(vol, loc_shift, interp_method='linear', indexing='ij'):
         interp_method (default:'linear'): 'linear', 'nearest'
         indexing (default: 'ij'): 'ij' (matrix) or 'xy' (cartesian).
             In general, prefer to leave this 'ij'
+        fill_value (default: None): value to use for points outside the domain.
+            If None, the nearest neighbors will be used.
     
     Return:
         new interpolated volumes in the same size as loc_shift[0]
@@ -287,7 +298,7 @@ def transform(vol, loc_shift, interp_method='linear', indexing='ij'):
     loc = [tf.cast(mesh[d], 'float32') + loc_shift[..., d] for d in range(nb_dims)]
 
     # test single
-    return interpn(vol, loc, interp_method=interp_method)
+    return interpn(vol, loc, interp_method=interp_method, fill_value=fill_value)
 
 
 def compose(disp_1, disp_2, indexing='ij'):


### PR DESCRIPTION
Add option `fill_value` to `neuron.utils.interpn`, `neuron.utils.transform` and `neuron.layers.SpatialTransformer`, for specifying an extrapolation value to use for points outside the valid domain.

Currently, nearest-neighbor extrapolation is being performed, which is not always desirable. The default `fill_value=None` reproduces current behavior.

Example using the default `fill_value=None` (current behavior):
<img width="771" alt="1_fill_value_none" src="https://user-images.githubusercontent.com/29034767/84710577-7f77ba80-af32-11ea-8b57-76fd2179bc7d.png">

Example using `fill_value=0`:
<img width="762" alt="2_fill_value_0" src="https://user-images.githubusercontent.com/29034767/84710584-81da1480-af32-11ea-8d15-05d073e90ccf.png">
