### PR TITLE
Improve performance

### DIFF
--- a/neurite/tf/utils/utils.py
+++ b/neurite/tf/utils/utils.py
@@ -155,6 +155,7 @@ def interpn(vol, loc, interp_method='linear', fill_value=None):
         # e.g. [0, 0] means this "first" corner in a 2-D "cube"
         cube_pts = list(itertools.product([0, 1], repeat=nb_dims))
         interp_vol = 0
+        vol_reshape = tf.reshape(vol, [-1, volshape[-1]])
 
         for c in cube_pts:
 
@@ -171,7 +172,7 @@ def interpn(vol, loc, interp_method='linear', fill_value=None):
             # vol_val = tf.gather_nd(vol, indices)
             # faster way to gather than gather_nd, because gather_nd needs tf.stack which is slow :(
             idx = sub2ind2d(vol.shape[:-1], subs)
-            vol_reshape = tf.reshape(vol, [-1, volshape[-1]])
+
             vol_val = tf.gather(vol_reshape, idx)
 
             # get the weight of this cube_pt based on the distance


### PR DESCRIPTION
# issue: Performance issue in the definition of interpn, neurite/tf/utils/utils.py 
Thank you for replying me! Frankly speaking, I never take a test. As you said, [tf.reshape(vol, [-1, volshape[-1]])](https://github.com/adalca/neurite/blob/f7324931c27b47309c9eeedeb56a47e2b6d1a97f/neurite/tf/utils/utils.py#L174) costs a bit of time to be executed. However, if there are lots of this bugs in our program or they are called for many times, performance will reduce sharply. I have done some experiments in other projects. So I hope we pay attention to details in coding. Finally, check the pr please. Looking forward to your Confirmation.