### PR TITLE
Create publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+# ref: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish Package
+
+on:
+  # publish from the Releases page:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish Package
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v3
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build
+      run: python -m build
+
+    - name: Publish to Github
+      uses: softprops/action-gh-release@v1
+      with:
+        files: 'dist/*'
+        fail_on_unmatched_files: true
+        prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'dev') }}
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This GitHub Action builds wheels and sdists and pushes them to GitHub's releases page and PyPI.
All you have to do is go to [New Release](https://github.com/adalca/neurite/releases/new), fill in a version tag like "v0.1.1", click Publish, and a couple minutes later the .whl and .tar.gz will be up on [Releases](https://github.com/adalca/neurite/releases) and on [PyPI](https://pypi.org/project/neurite).

To get PyPI working, [get a PyPI token](https://pypi.org/manage/account/token/), give it to GitHub [here](https://github.com/adalca/neurite/settings/secrets/actions) named `PYPI_TOKEN`.

To get a feel for it, you can see examples of how this looks in practice at

* https://github.com/ivadomed/ivadomed/actions/workflows/publish_package.yml

And the kinds of outputs it makes at

* https://github.com/ivadomed/ivadomed/releases/
* https://pypi.org/project/ivadomed/#history
