### PR TITLE
Make version-checking compatible with updated Packaging library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import pathlib
 import setuptools
 
 setuptools.dist.Distribution().fetch_build_eggs(['packaging'])
-import packaging.version
+from packaging.version import InvalidVersion, parse
 
 
 # base source directory
@@ -19,7 +19,9 @@ match = re.search(pattern, init_text, re.M)
 if not match:
     raise RuntimeError(f'Unable to find __version__ in {init_file}.')
 version = match.group(1)
-if isinstance(packaging.version.parse(version), packaging.version.LegacyVersion):
+try:
+    version_obj = parse(version)
+except InvalidVersion:
     raise RuntimeError(f'Invalid version string {version}.')
 
 # run setup


### PR DESCRIPTION
Recently the `packaging` library removed the `LegacyVersion` class [1]. This has resulted in Neurite's `setup.py` script throwing the following error at installation time:
`AttributeError: module 'packaging.version' has no attribute 'LegacyVersion'`

Proposed fix: 
Instead of checking if the (parsed) `version` string is a `LegacyVersion` object, use the `packaging.version.parse(version)` function to parse the `version` string and catch any `InvalidVersion` exception. If an exception is raised, then its not a valid `version` string according to the PEP 440 specification.

[1] https://github.com/pypa/packaging/issues/530