### PR TITLE
Fixed deprecated inspect.getargspec dependency in tf/modelio.py

### DIFF
--- a/neurite/tf/modelio.py
+++ b/neurite/tf/modelio.py
@@ -13,7 +13,7 @@ def store_config_args(func):
     """
 
     attrs, varargs, varkw, defaults, kwonlyargs, kwonlydefaults = \
-        inspect.getargspec(func)
+        inspect.getfullargspec(func)
 
 
     @functools.wraps(func)

--- a/neurite/tf/modelio.py
+++ b/neurite/tf/modelio.py
@@ -12,7 +12,9 @@ def store_config_args(func):
     model loading - see LoadableModel.
     """
 
-    attrs, varargs, varkw, defaults = inspect.getargspec(func)
+    attrs, varargs, varkw, defaults, kwonlyargs, kwonlydefaults = \
+        inspect.getargspec(func)
+
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -27,6 +29,9 @@ def store_config_args(func):
         if defaults:
             for attr, val in zip(reversed(attrs), reversed(defaults)):
                 params[attr] = val
+
+        # add defaults from keyword arguments too
+        params.update(kwonlydefaults)
 
         # next handle positional args
         for attr, val in zip(attrs[1:], args):

--- a/neurite/tf/modelio.py
+++ b/neurite/tf/modelio.py
@@ -12,9 +12,8 @@ def store_config_args(func):
     model loading - see LoadableModel.
     """
 
-    attrs, varargs, varkw, defaults, kwonlyargs, kwonlydefaults = \
+    attrs, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations = \
         inspect.getfullargspec(func)
-
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):


### PR DESCRIPTION
The method `inspect.getargspec()` has been replaced by `inspect.getfullargspec()`, which has different but partially overlapping return values. The code was updated here, but not tested yet. The change also affects voxelmorph. Please see the relevant pull request there.