### PR TITLE
Remove warning about deprecated `dtype` argument.

### DIFF
--- a/neurite/tf/layers.py
+++ b/neurite/tf/layers.py
@@ -2584,7 +2584,7 @@ class HyperConv(Layer):
         Runs per-batch convolution on the inputs, consisting of input features, kernels weights,
         and optional bias weights (when use_bias is True).
         """
-        outputs = tf.map_fn(self._convolve_batch, inputs, inputs[0].dtype)
+        outputs = tf.map_fn(self._convolve_batch, inputs, fn_output_signature=inputs[0].dtype)
         if self.activation is not None:
             outputs = self.activation(outputs)
         return outputs


### PR DESCRIPTION
```
WARNING:tensorflow:From /usr/local/lib/python3.11/dist-packages/tensorflow/python/util/deprecation.py:660: calling map_fn_v2 (from tensorflow.python.ops.map_fn) with dtype is deprecated and will be removed in a future version.
Instructions for updating:
Use fn_output_signature instead
```