### PR TITLE
Cast constant to desired output type.

### DIFF
--- a/neurite/tf/layers.py
+++ b/neurite/tf/layers.py
@@ -2835,7 +2835,7 @@ class Constant(Layer):
         return config
 
     def build(self, _):
-        self.const = tf.constant(self.value, self.dtype)
+        self.const = tf.cast(self.value, self.dtype)
         if tf.rank(self.const) == 0:
             self.const = tf.reshape(self.const, shape=(1,))
 


### PR DESCRIPTION
`tf.constant` cannot change the data type if `self.value` is already a tensor.