### PR TITLE
Add Default Backend Change Warning for PyTorch Transition

### DIFF
--- a/neurite/__init__.py
+++ b/neurite/__init__.py
@@ -17,11 +17,8 @@ __version__ = '0.2'
 # check whether pystrum version is valid
 from packaging import version
 import pystrum
-import warnings
-
 minv = '0.2'
 curv = getattr(pystrum, '__version__', None)
-
 if curv is None or version.parse(curv) < version.parse(minv):
     raise ImportError(f'neurite requires pystrum version {minv} or greater, '
                       f'but found version {curv}')
@@ -34,7 +31,6 @@ from .py import dataproc
 
 # import backend-dependent submodules
 backend = py.utils.get_backend()
-
 if backend == 'pytorch':
     # the pytorch backend can be enabled by setting the NEURITE_BACKEND
     # environment var to "pytorch"
@@ -42,16 +38,9 @@ if backend == 'pytorch':
         import torch
     except ImportError:
         raise ImportError('Please install pytorch to use this neurite backend')
+
     from . import torch
 else:
-    warnings.warn(
-        "The TensorFlow backend is deprecated and will soon be unsupported. We encourage you to "
-        "migrate to the PyTorch backend, which will receive full support and ongoing maintenance. "
-        "For migration instructions, please visit "
-        "https://github.com/adalca/neurite/migration-guide.",
-        FutureWarning,
-        stacklevel=2
-        )
     # tensorflow is default backend
     try:
         import tensorflow

--- a/neurite/__init__.py
+++ b/neurite/__init__.py
@@ -34,7 +34,6 @@ from .py import dataproc
 
 # import backend-dependent submodules
 backend = py.utils.get_backend()
-backend = 'pytorch'
 
 if backend == 'pytorch':
     # the pytorch backend can be enabled by setting the NEURITE_BACKEND

--- a/neurite/__init__.py
+++ b/neurite/__init__.py
@@ -17,8 +17,11 @@ __version__ = '0.2'
 # check whether pystrum version is valid
 from packaging import version
 import pystrum
+import warnings
+
 minv = '0.2'
 curv = getattr(pystrum, '__version__', None)
+
 if curv is None or version.parse(curv) < version.parse(minv):
     raise ImportError(f'neurite requires pystrum version {minv} or greater, '
                       f'but found version {curv}')
@@ -31,6 +34,8 @@ from .py import dataproc
 
 # import backend-dependent submodules
 backend = py.utils.get_backend()
+backend = 'pytorch'
+
 if backend == 'pytorch':
     # the pytorch backend can be enabled by setting the NEURITE_BACKEND
     # environment var to "pytorch"
@@ -38,9 +43,16 @@ if backend == 'pytorch':
         import torch
     except ImportError:
         raise ImportError('Please install pytorch to use this neurite backend')
-
     from . import torch
 else:
+    warnings.warn(
+        "The TensorFlow backend is deprecated and will soon be unsupported. We encourage you to "
+        "migrate to the PyTorch backend, which will receive full support and ongoing maintenance. "
+        "For migration instructions, please visit "
+        "https://github.com/adalca/neurite/migration-guide.",
+        FutureWarning,
+        stacklevel=2
+        )
     # tensorflow is default backend
     try:
         import tensorflow

--- a/neurite/py/utils.py
+++ b/neurite/py/utils.py
@@ -4,6 +4,7 @@ python utilities for neuron
 
 # internal python imports
 import os
+import warnings
 
 # third party imports
 import numpy as np
@@ -17,7 +18,19 @@ def get_backend():
     Returns the currently used backend. Default is tensorflow unless the
     NEURITE_BACKEND environment variable is set to 'pytorch'.
     """
-    return 'pytorch' if os.environ.get('NEURITE_BACKEND') == 'pytorch' else 'tensorflow'
+    backend = os.environ.get('NEURITE_BACKEND')
+    # Determine if backend has been defined
+    if backend not in {'tensorflow', 'pytorch'}:
+        # If not, set backend to the current default (TensorFlow)
+        backend = 'tensorflow'
+        # Issue warning about the default change to pytorch in the future
+        warnings.warn(
+            "The default backend will soon be changing to 'pytorch'. If you prefer to use "
+            "TensorFlow, please set the NEURITE_BACKEND environment variable to 'tensorflow'.",
+            FutureWarning,
+            stacklevel=2
+        )
+    return backend
 
 
 def softmax(x, axis):


### PR DESCRIPTION
Added a future warning for the transition from TensorFlow to PyTorch.

* **Reason**: To streamline development and maintenance efforts by focusing mostly on the PyTorch backend.
* **Impact**: Users who have not explicitly set a backend (in the environment variable `NEURITE_BACKEND`) will receive a warning upon importing neurite, encouraging them to consider using 'tensorflow' as the `NEURITE_BACKEND`, or migrating to PyTorch for continued support and updates.