### PR TITLE
[fix] type hint and default for cmaps in plot.slices

### DIFF
--- a/neurite/py/plot.py
+++ b/neurite/py/plot.py
@@ -36,7 +36,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable  # plotting
 def slices(
     slices_in: Union[np.ndarray, torch.Tensor, Sequence[Union[np.ndarray, torch.Tensor]]],
     titles: Union[str, List[str], None] = None,
-    cmaps=Sequence[Union[str, Colormap]],
+    cmaps: Sequence[Union[str, Colormap]] = None,
     norms=None,
     do_colorbars: bool = False,
     grid: bool = False,          # option to plot the images in a grid or a single row


### PR DESCRIPTION
Fix error in `ne.plot.slices` and `ne.plot.volume3D` when `cmaps` are not specified:

```
TypeError: object of type '_GenericAlias' has no len()
...
  File "...", line 246, in volume3D
    return ne.py.plot.volume3D(
           ^^^^^^^^^^^^^^^^^^^^
  File "/autofs/cluster/dalcalab2/users/hew19/interseg3d/work/neurite/neurite/py/plot.py", line 246, in volume3D
    return slices(slics, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/autofs/cluster/dalcalab2/users/hew19/interseg3d/work/neurite/neurite/py/plot.py", line 126, in slices
    cmaps = input_check(cmaps, nb_plots, 'cmaps', default='gray')
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/autofs/cluster/dalcalab2/users/hew19/interseg3d/work/neurite/neurite/py/plot.py", line 117, in input_check
    assert (inputs is None) or (len(inputs) == nb_plots) or (len(inputs) == 1), \
                                ^^^^^^^^^^^
TypeError: object of type '_GenericAlias' has no len()
```